### PR TITLE
Use ruff for format and lint

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,6 +11,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint_and_format_check_with_ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check"
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -26,14 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest-cov
           pip install -e ".[testing]"
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
           pytest --cov tadasets

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@ sys.path.insert(0, os.path.abspath("."))
 from tadasets import __version__
 from sktda_docs_config import *
 
-project = u"TaDAsets"
-copyright = u"2018, Nathaniel Saul"
-author = u"Nathaniel Saul"
+project = "TaDAsets"
+copyright = "2018, Nathaniel Saul"
+author = "Nathaniel Saul"
 
 version = __version__
 release = __version__
@@ -28,7 +28,7 @@ htmlhelp_basename = "TaDAsetsdoc"
 
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
- 
+
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":
     if "html_context" not in globals():

--- a/docs/notebooks/Examples.ipynb
+++ b/docs/notebooks/Examples.ipynb
@@ -135,7 +135,7 @@
    ],
    "source": [
     "t = tadasets.infty_sign()\n",
-    "plt.scatter(t[:,0],t[:,1])\n",
+    "plt.scatter(t[:, 0], t[:, 1])\n",
     "plt.show()"
    ]
   },
@@ -164,7 +164,7 @@
    ],
    "source": [
     "t = tadasets.infty_sign(noise=0.05)\n",
-    "plt.scatter(t[:,0],t[:,1])\n",
+    "plt.scatter(t[:, 0], t[:, 1])\n",
     "plt.show()"
    ]
   },
@@ -186,7 +186,7 @@
    ],
    "source": [
     "t = tadasets.dsphere(d=1)\n",
-    "plt.scatter(t[:,0],t[:,1])\n",
+    "plt.scatter(t[:, 0], t[:, 1])\n",
     "plt.show()"
    ]
   },
@@ -207,8 +207,8 @@
     }
    ],
    "source": [
-    "t = tadasets.eyeglasses(n=250,r1=10,r2=5)\n",
-    "plt.scatter(t[:,0],t[:,1])\n",
+    "t = tadasets.eyeglasses(n=250, r1=10, r2=5)\n",
+    "plt.scatter(t[:, 0], t[:, 1])\n",
     "plt.show()"
    ]
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ testing = ["pytest", "pytest-cov", "scipy"]
 
 docs = ["sktda_docs_config"]
 
+ruff = ["ruff<0.12.0"]
+
 [project.urls]
 Homepage = "https://tadasets.scikit-tda.org"
 Documentation = "https://tadasets.scikit-tda.org"

--- a/tadasets/dimension.py
+++ b/tadasets/dimension.py
@@ -1,5 +1,5 @@
 """
-    Methods for embedding objects in high dimensional space.
+Methods for embedding objects in high dimensional space.
 
 """
 
@@ -7,7 +7,7 @@ import numpy as np
 
 
 def embed(data, ambient=50):
-    """ Embed `data` in `ambient` dimensions, regardless of dimensionality of data.
+    """Embed `data` in `ambient` dimensions, regardless of dimensionality of data.
 
     Inputs
     ------
@@ -18,10 +18,10 @@ def embed(data, ambient=50):
     """
 
     n, d = data.shape
-    assert (
-        ambient > d
-    ), "Dimensionality of ambient space ({}) must be greater than dimensionality of data ({}).".format(
-        ambient, d
+    assert ambient > d, (
+        "Dimensionality of ambient space ({}) must be greater than dimensionality of data ({}).".format(
+            ambient, d
+        )
     )
 
     base = np.zeros((n, ambient))

--- a/tadasets/sample.py
+++ b/tadasets/sample.py
@@ -1,5 +1,5 @@
 """
-    Methods for constructing point clouds from meshes.
+Methods for constructing point clouds from meshes.
 
 """
 
@@ -40,7 +40,7 @@ def from_mesh(vertices, triangles, n=1000):
     V2 = P2 - P0
     FNormals = np.cross(V1, V2)
     # import pdb; pdb.set_trace()
-    FAreas = np.sqrt(np.sum(FNormals ** 2, 1)).flatten()
+    FAreas = np.sqrt(np.sum(FNormals**2, 1)).flatten()
 
     # Get rid of zero area faces and update points
     triangles = triangles[FAreas > 0, :]
@@ -89,7 +89,7 @@ def from_mesh(vertices, triangles, n=1000):
 
     # Vector used to determine if points need to be flipped across parallelogram
     V3 = P2 - P1
-    V3 = V3 / np.sqrt(np.sum(V3 ** 2, 1))[:, None]  # Normalize
+    V3 = V3 / np.sqrt(np.sum(V3**2, 1))[:, None]  # Normalize
 
     # Randomly sample points on each face
     # Generate random points uniformly in parallelogram

--- a/tadasets/shapes.py
+++ b/tadasets/shapes.py
@@ -248,10 +248,10 @@ def infty_sign(
     if noise:
         X += noise * np.random.randn(n, 2)
     if angle is not None:
-        assert (
-            angle >= -np.pi and angle <= 2 * np.pi
-        ), "Angle {angle} not in range. Angle should be in the range {min_angle} <= angle <= {max_angle}".format(
-            angle=angle, min_angle="-pi", max_angle="2*pi"
+        assert angle >= -np.pi and angle <= 2 * np.pi, (
+            "Angle {angle} not in range. Angle should be in the range {min_angle} <= angle <= {max_angle}".format(
+                angle=angle, min_angle="-pi", max_angle="2*pi"
+            )
         )
 
         X = rotate_2D(X, angle=angle)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -6,7 +6,6 @@ from tadasets.sample import from_mesh
 
 class TestMeshSampler:
     def test_unit_square(self):
-
         vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]])
 
         tris = np.array([[0, 1, 2], [1, 2, 3]])

--- a/test/test_shapes.py
+++ b/test/test_shapes.py
@@ -5,7 +5,7 @@ from scipy.spatial.distance import pdist
 
 
 def norm(p):
-    return np.sum(p ** 2) ** 0.5
+    return np.sum(p**2) ** 0.5
 
 
 class TestEmbedding:
@@ -15,7 +15,7 @@ class TestEmbedding:
         assert d_emb.shape == (100, 10)
 
     def test_rotated(self):
-        """ No variables should be all zero.
+        """No variables should be all zero.
         Nonzero variance implies some transformation happened.
         """
         d = np.random.random((100, 3))
@@ -119,18 +119,18 @@ class TestInfty:
 
 class TestEyeglasses:
     def test_n(self):
-        t = tadasets.eyeglasses(n=345, r1=1, r2=2, neck_size=.8)
+        t = tadasets.eyeglasses(n=345, r1=1, r2=2, neck_size=0.8)
         assert t.shape[0] == 345
 
     def test_neck(self):
-        t = tadasets.eyeglasses(n=5000, r1=1, r2=2, neck_size=.8)
+        t = tadasets.eyeglasses(n=5000, r1=1, r2=2, neck_size=0.8)
         top, bottom = t[t[:, 1] > 0], t[t[:, 1] < 0]
         y_neck_top = top[np.abs(top[:, 0]).argmin(), 1]
         y_neck_bottom = bottom[np.abs(bottom[:, 0]).argmin(), 1]
-        assert np.abs(y_neck_top - y_neck_bottom - .8) <= .001
+        assert np.abs(y_neck_top - y_neck_bottom - 0.8) <= 0.001
 
     def test_r(self):
-        t = tadasets.eyeglasses(n=5000, r1=1, r2=2, neck_size=.8)
+        t = tadasets.eyeglasses(n=5000, r1=1, r2=2, neck_size=0.8)
         left, right = t[t[:, 0] < 0], t[t[:, 0] > 0]
-        assert np.abs(left[:, 1].max() - 1) <= .001
-        assert np.abs(right[:, 1].max() - 2) <= .001
+        assert np.abs(left[:, 1].max() - 1) <= 0.001
+        assert np.abs(right[:, 1].max() - 2) <= 0.001


### PR DESCRIPTION
This PR will switch over from flake8 and black to ruff. This will also update the python versions used for testing and the doc builds.