### PR TITLE
Update code-cov workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -45,7 +45,10 @@ jobs:
           pip install -e ".[testing]"
       - name: Test with pytest
         run: |
-          pytest --cov tadasets
+          pytest --cov=./ --cov-report=xml
       - name: Upload coverage results
-        run: |
-          bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v5
+        with:
+          name: tadasets
+          verbose: true
+          fail_ci_if_error: true

--- a/tadasets/shapes.py
+++ b/tadasets/shapes.py
@@ -7,9 +7,9 @@ __all__ = ["torus", "dsphere", "sphere", "swiss_roll", "infty_sign", "eyeglasses
 
 
 # TODO: Make a base class that controls `ambient` and `noise`.
-class Shape:
-    def __init__(self):
-        pass
+# class Shape:
+# def __init__(self):
+# pass
 
 
 def dsphere(
@@ -44,14 +44,14 @@ def dsphere(
         An ``(n,ambient)`` np.ndarray if ``ambient`` is specifed or
         a ``(n,d+1)`` np.ndarray otherwise.
     """
-    np.random.seed(seed)
-    data = np.random.randn(n, d + 1)
+    rng = np.random.default_rng(seed)
+    data = rng.standard_normal((n, d + 1))
 
     # Normalize points to the sphere
     data = r * data / np.sqrt(np.sum(data**2, 1)[:, None])
 
     if noise:
-        data += noise * np.random.randn(*data.shape)
+        data += noise * rng.standard_normal(data.shape)
 
     if ambient:
         assert ambient > d, "Must embed in higher dimensions"
@@ -89,9 +89,9 @@ def sphere(
         An ``(n,3)`` np.ndarray.
     """
 
-    np.random.seed(seed)
-    theta = np.random.random((n,)) * 2.0 * np.pi
-    phi = np.random.random((n,)) * np.pi
+    rng = np.random.default_rng(seed)
+    theta = rng.random(n) * 2.0 * np.pi
+    phi = rng.random(n) * np.pi
     rad = np.ones((n,)) * r
 
     data = np.zeros((n, 3))
@@ -101,7 +101,7 @@ def sphere(
     data[:, 2] = rad * np.sin(theta)
 
     if noise:
-        data += noise * np.random.randn(*data.shape)
+        data += noise * rng.standard_normal(data.shape)
 
     if ambient:
         data = embed(data, ambient)
@@ -143,9 +143,9 @@ def torus(
 
     assert a <= c, "That's not a torus"
 
-    np.random.seed(seed)
-    theta = np.random.random((n,)) * 2.0 * np.pi
-    phi = np.random.random((n,)) * 2.0 * np.pi
+    rng = np.random.default_rng(seed)
+    theta = rng.random(n) * 2.0 * np.pi
+    phi = rng.random(n) * 2.0 * np.pi
 
     data = np.zeros((n, 3))
     data[:, 0] = (c + a * np.cos(theta)) * np.cos(phi)
@@ -153,7 +153,7 @@ def torus(
     data[:, 2] = a * np.sin(theta)
 
     if noise:
-        data += noise * np.random.randn(*data.shape)
+        data += noise * rng.standard_normal(data.shape)
 
     if ambient:
         data = embed(data, ambient)
@@ -194,9 +194,9 @@ def swiss_roll(
         An ``(n,3)`` np.ndarray.
     """
 
-    np.random.seed(seed)
-    phi = (np.random.random((n,)) * 3 + 1.5) * np.pi
-    psi = np.random.random((n,)) * r
+    rng = np.random.default_rng(seed)
+    phi = (rng.random(n) * 3 + 1.5) * np.pi
+    psi = rng.random(n) * r
 
     data = np.zeros((n, 3))
     data[:, 0] = phi * np.cos(phi)
@@ -204,7 +204,7 @@ def swiss_roll(
     data[:, 2] = psi
 
     if noise:
-        data += noise * np.random.randn(*data.shape)
+        data += noise * rng.standard_normal(data.shape)
 
     if ambient:
         data = embed(data, ambient)
@@ -238,15 +238,14 @@ def infty_sign(
     data : np.ndarray
         An ``(n,2)`` np.ndarray.
     """
-
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     t = np.linspace(0, 2 * np.pi, n + 1)[0:n]
     X = np.zeros((n, 2))
     X[:, 0] = np.cos(t)
     X[:, 1] = np.sin(2 * t)
 
     if noise:
-        X += noise * np.random.randn(n, 2)
+        X += noise * rng.standard_normal((n, 2))
     if angle is not None:
         assert angle >= -np.pi and angle <= 2 * np.pi, (
             "Angle {angle} not in range. Angle should be in the range {min_angle} <= angle <= {max_angle}".format(
@@ -265,7 +264,7 @@ def eyeglasses(
     neck_size: Optional[float] = None,
     noise: Optional[float] = None,
     ambient: Optional[int] = None,
-    seed: Optional[float] = None,
+    seed: Optional[int] = None,
 ) -> np.ndarray:
     """Sample ``n`` points on an eyeglasses shape.
 
@@ -293,7 +292,7 @@ def eyeglasses(
         An ``(n,ambient)`` np.ndarray if ``ambient`` is specified or
         an ``(n,2)`` np.ndarray otherwise.
     """
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
 
     if r2 is None:
         r2 = r1
@@ -344,9 +343,7 @@ def eyeglasses(
 
     data = []
     for x in ["l", "r", "t", "b"]:
-        angles = np.random.uniform(
-            size=counts[x], low=angle_ranges[x][0], high=angle_ranges[x][1]
-        )
+        angles = rng.uniform(angle_ranges[x][0], angle_ranges[x][1], counts[x])
         points = (
             np.vstack((radii[x] * np.cos(angles), radii[x] * np.sin(angles))).T
             + centers[x]
@@ -356,7 +353,7 @@ def eyeglasses(
     data = np.concatenate(data)
 
     if noise:
-        data += noise * np.random.randn(n, 2)
+        data += noise * rng.standard_normal((n, 2))
 
     if ambient:
         data = embed(data, ambient)

--- a/test/test_rotate.py
+++ b/test/test_rotate.py
@@ -1,0 +1,9 @@
+from tadasets.rotate import rotate_2D
+import numpy as np
+import pytest
+
+
+def test_rotate_2D():
+    with pytest.raises(ValueError) as ve:
+        rotate_2D(np.array([[1, 2, 3], [4, 5, 6]]), 0)
+        assert ve is not None

--- a/test/test_shapes.py
+++ b/test/test_shapes.py
@@ -48,6 +48,11 @@ class TestSphere:
         s = tadasets.sphere(n=200, r=3, ambient=15)
         assert s.shape == (200, 15)
 
+    def test_noise(self):
+        s = tadasets.sphere(n=100, noise=0.1)
+        rs = np.fromiter((norm(p) for p in s), np.float64)
+        assert np.any(rs != 1.0)
+
 
 class TestDsphere:
     def test_d(self):
@@ -64,10 +69,19 @@ class TestDsphere:
         rs = np.fromiter((norm(p) for p in s), np.float64)
         assert np.all([4 - 1e-5 <= r <= 4 + 1e-5 for r in rs])
 
+    def test_noise(self):
+        s = tadasets.dsphere(n=100, d=2, noise=0.1)
+        rs = np.fromiter((norm(p) for p in s), np.float64)
+        assert np.any(rs != 1.0)
+
+    def test_ambient(self):
+        s = tadasets.dsphere(n=200, d=2, ambient=15)
+        assert s.shape == (200, 15)
+
 
 class TestTorus:
     def test_n(self):
-        t = tadasets.torus(n=345)
+        t = tadasets.torus(n=345, noise=0.1)
         assert t.shape[0] == 345
 
     def test_bounds(self):
@@ -89,7 +103,7 @@ class TestTorus:
 
 class TestSwissRoll:
     def test_n(self):
-        t = tadasets.swiss_roll(n=345)
+        t = tadasets.swiss_roll(n=345, noise=0.1)
         assert t.shape[0] == 345
 
     def test_plt(self):
@@ -103,7 +117,7 @@ class TestSwissRoll:
 
 class TestInfty:
     def test_n(self):
-        t = tadasets.infty_sign(n=345)
+        t = tadasets.infty_sign(n=345, noise=0.1)
         assert t.shape[0] == 345
 
     def test_rotation(self):
@@ -119,7 +133,7 @@ class TestInfty:
 
 class TestEyeglasses:
     def test_n(self):
-        t = tadasets.eyeglasses(n=345, r1=1, r2=2, neck_size=0.8)
+        t = tadasets.eyeglasses(n=345, r1=1, r2=2, neck_size=0.8, noise=0.1)
         assert t.shape[0] == 345
 
     def test_neck(self):
@@ -134,3 +148,12 @@ class TestEyeglasses:
         left, right = t[t[:, 0] < 0], t[t[:, 0] > 0]
         assert np.abs(left[:, 1].max() - 1) <= 0.001
         assert np.abs(right[:, 1].max() - 2) <= 0.001
+
+    def test_r2(self):
+        t = tadasets.eyeglasses(n=5000, r1=1)
+        left, _ = t[t[:, 0] < 0], t[t[:, 0] > 0]
+        assert np.abs(left[:, 1].max() - 1) <= 0.001
+
+    def test_ambient(self):
+        s = tadasets.eyeglasses(n=200, r1=1, r2=2, neck_size=0.8, ambient=15)
+        assert s.shape == (200, 15)


### PR DESCRIPTION
The current way of updating code coverage is deprecated https://docs.codecov.com/docs/about-the-codecov-bash-uploader. The code coverage has not been updated in a while, and I think it is because of this. Regardless, this PR will update the code coverage action and then fix the coverage being displayed on PRs and uploaded to codecov.io appropriately. We should use this to find an appropriate solution before propagating to the rest of scikit-tda.