### PR TITLE
ci: Add codecov token to env

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -48,6 +48,8 @@ jobs:
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage results
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: tadasets
           verbose: true


### PR DESCRIPTION
Uploading to codecov works without a token for non-protected branches, like on a PR, but fails on main because it is protected. This PR will update the upload action to use the token stored in the GH environment.